### PR TITLE
Preparing build - crates.io

### DIFF
--- a/minigrep/Cargo.lock
+++ b/minigrep/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "minigrep"
-version = "0.1.0"
+version = "0.0.1"

--- a/minigrep/Cargo.lock
+++ b/minigrep/Cargo.lock
@@ -3,5 +3,5 @@
 version = 3
 
 [[package]]
-name = "minigrep"
+name = "saka_grep"
 version = "0.0.1"

--- a/minigrep/Cargo.toml
+++ b/minigrep/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "minigrep"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
-
+license = "MIT"
+description = "simple commandline utility to search contents in file"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/minigrep/Cargo.toml
+++ b/minigrep/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "@skariyania/minigrep"
+name = "saka-mgrep"
 version = "0.0.1"
 edition = "2021"
 license = "MIT"

--- a/minigrep/Cargo.toml
+++ b/minigrep/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "saka-mgrep"
+name = "saka_grep"
 version = "0.0.1"
 edition = "2021"
 license = "MIT"

--- a/minigrep/Cargo.toml
+++ b/minigrep/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "minigrep"
+name = "@skariyania/minigrep"
 version = "0.0.1"
 edition = "2021"
 license = "MIT"

--- a/minigrep/src/main.rs
+++ b/minigrep/src/main.rs
@@ -1,6 +1,6 @@
 use std::{env, process};
 
-use minigrep::{run, Config};
+use saka_grep::{run, Config};
 
 fn main() {
     let config: Config = Config::build(env::args()).unwrap_or_else(|err| {


### PR DESCRIPTION
crate deployed at [caretes.io](https://crates.io/crates/saka_grep)
